### PR TITLE
update github action workflow

### DIFF
--- a/.github/workflows/get_and_upload_uniswap_defillama_tvl_to_dune.yml
+++ b/.github/workflows/get_and_upload_uniswap_defillama_tvl_to_dune.yml
@@ -1,9 +1,9 @@
 name: Get Uniswap TVL from DefiLlama and upload it to Dune
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #  branches:
+  #    - main
   schedule:
     - cron: "0 10 * * *"
 


### PR DESCRIPTION
**Is this linked to an existing issue**

update: `.github/workflow/get_and_upload_uniswap_defillama_tvl_to_dune.yml` to prevent workflow action from triggered on every push to main. 

workflow continues to run daily. 

**Fill out the following table describing your edits:**

n/a

**Provide any other context or screenshots that explain or justify the changes above:**

n/a

**Note to Contributor:**

Make sure your PR edits the original `query_id.sql` file with the new query text. If you are proposing adding a new query completely, make sure to add it to `queries.yml` and as a file in `/queries` as well.

Thanks for contributing! 🙏